### PR TITLE
Rust beta compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/emk/rust-uchardet"
 readme = "README.md"
 keywords = ["encoding", "text", "i18n"]
 
-[dependencies.uchardet-sys]
+[dependencies]
+libc = "0.1"
+
+[dependencies.uchardet_sys]
 path = "uchardet-sys"
 version = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,8 @@
 
 #![deny(missing_docs)]
 
-#![feature(std_misc)]
-#![feature(core)]
-#![feature(libc)]
-
 extern crate libc;
-extern crate "uchardet-sys" as ffi;
+extern crate uchardet_sys as ffi;
 
 use libc::size_t;
 use std::error::Error;

--- a/uchardet-sys/Cargo.toml
+++ b/uchardet-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "uchardet-sys"
+name = "uchardet_sys"
 version = "0.0.11"
 authors = ["Eric Kidd <git@randomhacks.net>"]
 
@@ -12,6 +12,9 @@ repository = "https://github.com/emk/rust-uchardet"
 
 links = "uchardet"
 build = "build.rs"
+
+[dependencies]
+libc = "0.1"
 
 [build-dependencies]
 pkg-config = '*'

--- a/uchardet-sys/build.rs
+++ b/uchardet-sys/build.rs
@@ -59,7 +59,7 @@ fn main() {
     let cxx_abi = "stdc++";
 
     // Print out link instructions for Cargo.
-    println!("cargo:rustc-flags=-L {} -l uchardet:static -l {}",
+    println!("cargo:rustc-flags=-L {} -l static=uchardet -l {}",
              dst.join("lib").display(), cxx_abi);
     println!("cargo:root={}", dst.display());
 }

--- a/uchardet-sys/build.rs
+++ b/uchardet-sys/build.rs
@@ -4,10 +4,7 @@
 // This has been tested on Ubuntu and it assumes that CMake is available.
 // Patches are welcome to help make it work on other operating systems!
 
-#![feature(path)]
-#![feature(fs)]
-
-extern crate "pkg-config" as pkg_config;
+extern crate pkg_config;
 
 use std::env;
 use std::fs::{PathExt, create_dir};
@@ -38,9 +35,10 @@ fn main() {
 
     // Make a build directory.
     let build = dst.join("build");
-    if !build.is_dir() {
-        create_dir(&build).unwrap();
-    }
+    // This isn't ideal but until is_dir() is stable just always try to create
+    // the build directory. If it exists and error is returned, which is
+    // ignored.
+    create_dir(&build);
 
     // Set up our CMake command.
     run(Command::new("cmake")

--- a/uchardet-sys/src/lib.rs
+++ b/uchardet-sys/src/lib.rs
@@ -1,8 +1,6 @@
 //! Low-level, unsafe wrapper for the uchardet API.  Not intended to be
 //! used directly, unless you're writing your own wrapper.
 
-#![feature(libc)]
-
 extern crate libc;
 
 use libc::{c_char, c_int, c_void, size_t};


### PR DESCRIPTION
A few tweaks to get the library building on 1.0.0-beta.2. And a slight adjustment to the linker flags to get it to link on OS X (verified [still builds on Linux with Travis CI](https://travis-ci.org/wezm/rust-uchardet)).
