### PR TITLE
Address error caused by use of stability attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub fn detect_encoding_name(data: &[u8]) ->
 
 impl EncodingDetector {
     /// Deprecated API for detecting encoding names.
-    #[deprecated = "Use uchardet::detect_encoding_name instead"]
+    /// Use uchardet::detect_encoding_name instead
     pub fn detect(data: &[u8]) -> EncodingDetectorResult<Option<String>> {
         detect_encoding_name(data)
     }


### PR DESCRIPTION
These are no longer allowed outside the standard library as of rust beta
3 and cause, "error: stability attributes may not be used outside of the
standard library", if used.
