### PR TITLE
Use CMake to build uchardet and update upstream submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "uchardet-sys/uchardet"]
 	path = uchardet-sys/uchardet
-	url = https://github.com/BYVoid/uchardet
+	url = https://anongit.freedesktop.org/git/uchardet/uchardet.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 rust:
 - nightly
 - beta
-- 1.0.0
+- stable
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ unstable = []
 
 [dependencies]
 libc = "*"
+error-chain = "0.5"
 
 [dependencies.uchardet-sys]
 path = "uchardet-sys"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,9 @@
 //! ```
 //! use uchardet::detect_encoding_name;
 //!
-//! assert_eq!("ISO-8859-1".to_string(),
-//!            detect_encoding_name(&[0x46, 0x72, 0x61, 0x6e, 0xe7, 0x6f,
-//!                0x69, 0x73, 0xe9]).unwrap());
+//! assert_eq!("WINDOWS-1252",
+//!            detect_encoding_name(&[0x46, 0x93, 0x72, 0x61, 0x6e, 0xe7, 0x6f,
+//!                0x69, 0x73, 0xe9, 0x94]).unwrap());
 //! ```
 //!
 //! For more information, see [this project on
@@ -27,8 +27,9 @@ use libc::size_t;
 use std::ffi::CStr;
 use std::str::from_utf8;
 
-use errors::*;
+pub use errors::*;
 
+#[allow(missing_docs)]
 mod errors {
     error_chain! {
         errors {
@@ -57,13 +58,13 @@ struct EncodingDetector {
 /// ```
 /// use uchardet::detect_encoding_name;
 ///
-/// assert_eq!("ASCII".to_string(),
+/// assert_eq!("ASCII",
 ///            detect_encoding_name("ascii".as_bytes()).unwrap());
-/// assert_eq!("UTF-8".to_string(),
+/// assert_eq!("UTF-8",
 ///            detect_encoding_name("©français".as_bytes()).unwrap());
-/// assert_eq!("ISO-8859-1".to_string(),
-///            detect_encoding_name(&[0x46, 0x72, 0x61, 0x6e, 0xe7, 0x6f,
-///                0x69, 0x73, 0xe9]).unwrap());
+/// assert_eq!("WINDOWS-1252",
+///            detect_encoding_name(&[0x46, 0x93, 0x72, 0x61, 0x6e, 0xe7, 0x6f,
+///                0x69, 0x73, 0xe9, 0x94]).unwrap());
 /// ```
 pub fn detect_encoding_name(data: &[u8]) -> Result<String> {
     let mut detector = EncodingDetector::new();
@@ -110,7 +111,7 @@ impl EncodingDetector {
     // }
 
     /// Get the decoder's current best guess as to the encoding. May return
-    /// an error if uchardet was unable to detect an encoding
+    /// an error if uchardet was unable to detect an encoding.
     fn charset(&self) -> Result<String> {
         unsafe {
             let internal_str = ffi::uchardet_get_charset(self.ptr);
@@ -119,7 +120,8 @@ impl EncodingDetector {
             let charset = from_utf8(bytes);
             match charset {
                 Err(_) =>
-                    panic!("uchardet_get_charset returned invalid value"),
+                    panic!("uchardet_get_charset returned a charset name \
+                            containing invalid characters"),
                 Ok("") => Err(ErrorKind::UnrecognizableCharset.into()),
                 Ok(encoding) => Ok(encoding.to_string())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! A wrapper around the uchardet library.  Detects character encodings.
+//! A wrapper around the uchardet library. Detects character encodings.
 //!
 //! Note that the underlying implemention is written in C and C++, and I'm
 //! not aware of any security audits which have been performed against it.
@@ -6,9 +6,8 @@
 //! ```
 //! use uchardet::detect_encoding_name;
 //!
-//! assert_eq!(Some("windows-1252".to_string()),
-//!            detect_encoding_name(&[0x66u8, 0x72, 0x61, 0x6e, 0xe7,
-//!                                 0x61, 0x69, 0x73]).unwrap());
+//! assert_eq!(Some("ISO-8859-1".to_string()),
+//!            detect_encoding_name(&[0x46, 0x72, 0x61, 0x6e, 0xe7, 0x6f, 0x69, 0x73, 0xe9]).unwrap());
 //! ```
 //!
 //! For more information, see [this project on
@@ -54,19 +53,22 @@ struct EncodingDetector {
 }
 
 /// Return the name of the charset used in `data`, or `None` if the
-/// charset is ASCII or if the encoding can't be detected.  This is
+/// charset if the encoding can't be detected. This is
 /// the value returned by the underlying `uchardet` library, with
 /// the empty string mapped to `None`.
 ///
 /// ```
 /// use uchardet::detect_encoding_name;
 ///
-/// assert_eq!(None, detect_encoding_name("ascii".as_bytes()).unwrap());
+/// assert_eq!(Some("ASCII".to_string()),
+///            detect_encoding_name("ascii".as_bytes()).unwrap());
 /// assert_eq!(Some("UTF-8".to_string()),
-///            detect_encoding_name("français".as_bytes()).unwrap());
-/// assert_eq!(Some("windows-1252".to_string()),
-///            detect_encoding_name(&[0x66u8, 0x72, 0x61, 0x6e, 0xe7,
-///                                 0x61, 0x69, 0x73]).unwrap());
+///            detect_encoding_name("©français".as_bytes()).unwrap());
+/// assert_eq!(Some("ISO-8859-1".to_string()),
+///            detect_encoding_name(&[0x46, 0x72, 0x61, 0x6e, 0xe7, 0x6f, 0x69, 0x73, 0xe9]).unwrap());
+
+
+
 /// ```
 pub fn detect_encoding_name(data: &[u8]) ->
     EncodingDetectorResult<Option<String>>
@@ -85,7 +87,7 @@ impl EncodingDetector {
         EncodingDetector{ptr: ptr}
     }
 
-    /// Pass a chunk of raw bytes to the detector.  This is a no-op if a
+    /// Pass a chunk of raw bytes to the detector. This is a no-op if a
     /// charset has been detected.
     fn handle_data(&mut self, data: &[u8]) -> EncodingDetectorResult<()> {
         let result = unsafe {
@@ -102,9 +104,9 @@ impl EncodingDetector {
     }
 
     /// Notify the detector that we're done calling `handle_data`, and that
-    /// we want it to make a guess as to our encoding.  This is a no-op if
+    /// we want it to make a guess as to our encoding. This is a no-op if
     /// no data has been passed yet, or if an encoding has been detected
-    /// for certain.  From reading the code, it appears that you can safely
+    /// for certain. From reading the code, it appears that you can safely
     /// call `handle_data` after calling this, but I'm not certain.
     fn data_end(&mut self) {
         unsafe { ffi::uchardet_data_end(self.ptr); }
@@ -115,7 +117,7 @@ impl EncodingDetector {
     //    unsafe { ffi::uchardet_reset(self.ptr); }
     //}
 
-    /// Get the decoder's current best guess as to the encoding.  Returns
+    /// Get the decoder's current best guess as to the encoding. Returns
     /// `None` on error, or if the data appears to be ASCII.
     fn charset(&self) -> Option<String> {
         unsafe {

--- a/uchardet-sys/Cargo.toml
+++ b/uchardet-sys/Cargo.toml
@@ -18,3 +18,4 @@ libc = "*"
 
 [build-dependencies]
 pkg-config = '*'
+cmake = "*"

--- a/uchardet-sys/build.rs
+++ b/uchardet-sys/build.rs
@@ -14,11 +14,18 @@ fn main() {
     if pkg_config::find_library("uchardet").is_ok() { return; }
 
     // Build uchardet ourselves
+    let mut config = Config::new("uchardet");
+
     // Mustn't build the binaries as they aren't compatible with Windows
     // and cause a compiler error
-    let dst = Config::new("uchardet")
-        .define("BUILD_BINARY", "OFF")
-        .build();
+    config.define("BUILD_BINARY", "OFF");
+
+    if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
+        // Disable sized deallocation as we're unable to link when it's enabled
+        config.cxxflag("-fno-sized-deallocation");
+    }
+
+    let dst = config.build();
 
     // Print out link instructions for Cargo.
     println!("cargo:rustc-link-search=native={}/lib", dst.display());

--- a/uchardet-sys/build.rs
+++ b/uchardet-sys/build.rs
@@ -20,6 +20,7 @@ fn main() {
     let cxx_abi = "stdc++";
 
     // Print out link instructions for Cargo.
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-search=native={}/lib64", dst.display());
     println!("cargo:rustc-link-lib=static=uchardet");
     println!("cargo:rustc-flags=-l {}", cxx_abi);

--- a/uchardet-sys/build.rs
+++ b/uchardet-sys/build.rs
@@ -7,21 +7,31 @@
 extern crate pkg_config;
 extern crate cmake;
 
+use cmake::Config;
+
 fn main() {
     // Do nothing if this package is already provided by the system.
     if pkg_config::find_library("uchardet").is_ok() { return; }
 
     // Build uchardet ourselves
-    let dst = cmake::build("uchardet");
-
-    // Decide how to link our C++ runtime.  Feel free to submit patches
-    // to make this work on your platform.  Other likely options are "c++"
-    // and "c++abi" depending on OS and compiler.
-    let cxx_abi = "stdc++";
+    // Mustn't build the binaries as they aren't compatible with Windows
+    // and cause a compiler error
+    let dst = Config::new("uchardet")
+        .define("BUILD_BINARY", "OFF")
+        .build();
 
     // Print out link instructions for Cargo.
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-search=native={}/lib64", dst.display());
     println!("cargo:rustc-link-lib=static=uchardet");
-    println!("cargo:rustc-flags=-l {}", cxx_abi);
+
+    if !(cfg!(target_os = "windows") && cfg!(target_env = "msvc")) {
+        // Not needed on windows-msvc
+
+        // Decide how to link our C++ runtime.  Feel free to submit patches
+        // to make this work on your platform.  Other likely options are "c++"
+        // and "c++abi" depending on OS and compiler.
+        let cxx_abi = "stdc++";
+        println!("cargo:rustc-flags=-l {}", cxx_abi);
+    }
 }

--- a/uchardet-sys/build.rs
+++ b/uchardet-sys/build.rs
@@ -5,53 +5,14 @@
 // Patches are welcome to help make it work on other operating systems!
 
 extern crate pkg_config;
-
-use std::env;
-use std::fs::create_dir;
-use std::path::Path;
-use std::process::{Command, Stdio};
+extern crate cmake;
 
 fn main() {
     // Do nothing if this package is already provided by the system.
     if pkg_config::find_library("uchardet").is_ok() { return; }
 
-    // Get our configuration from our environment.
-    let mut cxxflags = env::var("CXXFLAGS").unwrap_or(String::new());
-    let target = env::var("TARGET").unwrap();
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let src = Path::new(&manifest_dir);
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let dst = Path::new(&out_dir);
-
-    // Fix up our build flags.
-    if target.contains("i686") {
-        cxxflags.push_str(" -m32");
-    } else if target.contains("x86_64") {
-        cxxflags.push_str(" -m64");
-    }
-    if !target.contains("i686") {
-        cxxflags.push_str(" -fPIC");
-    }
-
-    // Make a build directory.
-    let build = dst.join("build");
-    // This isn't ideal but until is_dir() is stable just always try to create
-    // the build directory. If it exists and error is returned, which is
-    // ignored.
-    create_dir(&build).unwrap_or(());
-
-    // Set up our CMake command.
-    run(Command::new("cmake")
-            .current_dir(&dst.join("build"))
-            .arg(&src.join("uchardet"))
-            .arg("-DCMAKE_BUILD_TYPE=Release")
-            .arg(&format!("-DCMAKE_INSTALL_PREFIX={}", dst.display()))
-            .arg(&format!("-DCMAKE_CXX_FLAGS={}", cxxflags)));
-    
-    // Run our make command.
-    run(Command::new("make")
-            .current_dir(&dst.join("build"))
-            .arg("install"));
+    // Build uchardet ourselves
+    let dst = cmake::build("uchardet");
 
     // Decide how to link our C++ runtime.  Feel free to submit patches
     // to make this work on your platform.  Other likely options are "c++"
@@ -59,17 +20,7 @@ fn main() {
     let cxx_abi = "stdc++";
 
     // Print out link instructions for Cargo.
-    println!("cargo:rustc-flags=-L {} -l static=uchardet -l {}",
-             dst.join("lib").display(), cxx_abi);
-    println!("cargo:root={}", dst.display());
-}
-
-// Run an external build command.
-fn run(cmd: &mut Command) {
-    println!("running: {:?}", cmd);
-    assert!(cmd.stdout(Stdio::inherit())
-               .stderr(Stdio::inherit())
-               .status()
-               .unwrap()
-               .success());
+    println!("cargo:rustc-link-search=native={}/lib64", dst.display());
+    println!("cargo:rustc-link-lib=static=uchardet");
+    println!("cargo:rustc-flags=-l {}", cxx_abi);
 }

--- a/uchardet-sys/src/lib.rs
+++ b/uchardet-sys/src/lib.rs
@@ -8,11 +8,14 @@ use libc::{c_char, c_int, c_void, size_t};
 #[allow(non_camel_case_types)]
 pub type uchardet_t = *mut c_void;
 
+#[allow(non_camel_case_types)]
+pub type nsresult = c_int;
+
 extern {
     pub fn uchardet_new() -> uchardet_t;
     pub fn uchardet_delete(ud: uchardet_t);
     pub fn uchardet_handle_data(ud: uchardet_t, data: *const c_char,
-                                len: size_t) -> c_int;
+                                len: size_t) -> nsresult;
     pub fn uchardet_data_end(ud: uchardet_t);
     pub fn uchardet_reset(ud: uchardet_t);
     pub fn uchardet_get_charset(ud: uchardet_t) -> *const c_char;


### PR DESCRIPTION
Upstream change: see [README](https://github.com/BYVoid/uchardet)

Also had to change the examples a bit as the algorithm changed and other charsets are detected. `ASCII` is now a valid result of uchardet so we can directly return a `EncodingDetectorResult<String>`.

This is a breaking change.
