### PR TITLE
Only build static library

### DIFF
--- a/uchardet-sys/build.rs
+++ b/uchardet-sys/build.rs
@@ -18,6 +18,8 @@ fn main() {
     // Mustn't build the binaries as they aren't compatible with Windows
     // and cause a compiler error
     config.define("BUILD_BINARY", "OFF");
+    config.define("BUILD_STATIC", "ON");
+    config.define("BUILD_SHARED_LIBS", "OFF");
 
     if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
         // FIXME: This is only needed on newer versions of gcc (>5 ?); Older


### PR DESCRIPTION
Building both the dynamic and static library creates linker issues on some systems. CMake is trying to statically link `libuchardet.so.0.0.6` instead of `libuchardet.a`. Since the shared library is not needed anyway, it is not necessary to build it.

*Note:* This is clearly a workaround. I have not spent any time looking into why the linker is choosing the wrong library. However, this is the simplest path to support uchardet on alpine. 

<details>
<summary><b>Example for failing build on Alpine</b></summary>
<pre>
error: failed to run custom build command for `uchardet-sys v2.0.0`
process didn't exit successfully: `/tmp/sentry-cli-1.21.0/target/release/build/uchardet-sys-de96efdd507b27d4/build-script-build` (exit code: 101)
--- stdout
running: "cmake" "/root/.cargo/registry/src/github.com-1ecc6299db9ec823/uchardet-sys-2.0.0/uchardet" "-DBUILD_BINARY=OFF" "-DCMAKE_INSTALL_PREFIX=/tmp/sentry-cli-1.21.0/target/release/build/uchardet-sys-3100ef8028f6e95e/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 -static" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 -static" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_BUILD_TYPE=Release"
-- The CXX compiler identification is GNU 6.3.0
-- The C compiler identification is GNU 6.3.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Skipping test da:iso-8859-1 (known broken)
-- Skipping test es:iso-8859-15 (known broken)
-- Skipping test he:iso-8859-8 (known broken)
-- Skipping test ja:utf-16be (known broken)
-- Skipping test ja:utf-16le (known broken)
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/sentry-cli-1.21.0/target/release/build/uchardet-sys-3100ef8028f6e95e/out/build
running: "cmake" "--build" "." "--target" "install" "--config" "Release" "--" "-j4"
Scanning dependencies of target libuchardet
Scanning dependencies of target libuchardet_static
[  0%] Building CXX object src/CMakeFiles/libuchardet.dir/CharDistribution.cpp.o
[  1%] Building CXX object src/CMakeFiles/libuchardet.dir/JpCntx.cpp.o
[  2%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangArabicModel.cpp.o
[  3%] Building CXX object src/CMakeFiles/libuchardet_static.dir/CharDistribution.cpp.o
[  4%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangBulgarianModel.cpp.o
[  4%] Building CXX object src/CMakeFiles/libuchardet_static.dir/JpCntx.cpp.o
[  5%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangCroatianModel.cpp.o
[  6%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangCzechModel.cpp.o
[  7%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangEsperantoModel.cpp.o
[  8%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangArabicModel.cpp.o
[  9%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangEstonianModel.cpp.o
[ 10%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangFinnishModel.cpp.o
[ 11%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangBulgarianModel.cpp.o
[ 12%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangFrenchModel.cpp.o
[ 13%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangCroatianModel.cpp.o
[ 14%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangCzechModel.cpp.o
[ 15%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangDanishModel.cpp.o
[ 16%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangEsperantoModel.cpp.o
[ 17%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangEstonianModel.cpp.o
[ 18%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangGermanModel.cpp.o
[ 19%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangFinnishModel.cpp.o
[ 20%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangFrenchModel.cpp.o
[ 21%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangGreekModel.cpp.o
[ 22%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangHungarianModel.cpp.o
[ 23%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangDanishModel.cpp.o
[ 24%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangHebrewModel.cpp.o
[ 25%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangIrishModel.cpp.o
[ 26%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangGermanModel.cpp.o
[ 27%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangGreekModel.cpp.o
[ 28%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangHungarianModel.cpp.o
[ 29%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangItalianModel.cpp.o
[ 30%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangLithuanianModel.cpp.o
[ 31%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangHebrewModel.cpp.o
[ 32%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangLatvianModel.cpp.o
[ 33%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangIrishModel.cpp.o
[ 34%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangPolishModel.cpp.o
[ 35%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangMalteseModel.cpp.o
[ 36%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangPortugueseModel.cpp.o
[ 37%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangRomanianModel.cpp.o
[ 38%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangRussianModel.cpp.o
[ 39%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangSlovakModel.cpp.o
[ 40%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangSloveneModel.cpp.o
[ 41%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangSwedishModel.cpp.o
[ 42%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangSpanishModel.cpp.o
[ 43%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangItalianModel.cpp.o
[ 44%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangLithuanianModel.cpp.o
[ 45%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangThaiModel.cpp.o
[ 46%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangTurkishModel.cpp.o
[ 47%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangLatvianModel.cpp.o
[ 48%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangMalteseModel.cpp.o
[ 49%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangPolishModel.cpp.o
[ 50%] Building CXX object src/CMakeFiles/libuchardet.dir/LangModels/LangVietnameseModel.cpp.o
[ 51%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangPortugueseModel.cpp.o
[ 52%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangRomanianModel.cpp.o
[ 53%] Building CXX object src/CMakeFiles/libuchardet.dir/nsHebrewProber.cpp.o
[ 54%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangSlovakModel.cpp.o
[ 55%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangRussianModel.cpp.o
[ 56%] Building CXX object src/CMakeFiles/libuchardet.dir/nsCharSetProber.cpp.o
[ 57%] Building CXX object src/CMakeFiles/libuchardet.dir/nsBig5Prober.cpp.o
[ 58%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangSwedishModel.cpp.o
[ 59%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangSloveneModel.cpp.o
[ 60%] Building CXX object src/CMakeFiles/libuchardet.dir/nsEUCJPProber.cpp.o
[ 61%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangSpanishModel.cpp.o
[ 62%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangThaiModel.cpp.o
[ 63%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangTurkishModel.cpp.o
[ 64%] Building CXX object src/CMakeFiles/libuchardet_static.dir/LangModels/LangVietnameseModel.cpp.o
[ 65%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsHebrewProber.cpp.o
[ 66%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsCharSetProber.cpp.o
[ 67%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsBig5Prober.cpp.o
[ 68%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsEUCJPProber.cpp.o
[ 69%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsEUCKRProber.cpp.o
[ 70%] Building CXX object src/CMakeFiles/libuchardet.dir/nsEUCKRProber.cpp.o
[ 71%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsEUCTWProber.cpp.o
[ 72%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsEscCharsetProber.cpp.o
[ 73%] Building CXX object src/CMakeFiles/libuchardet.dir/nsEUCTWProber.cpp.o
[ 74%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsEscSM.cpp.o
[ 75%] Building CXX object src/CMakeFiles/libuchardet.dir/nsEscCharsetProber.cpp.o
[ 76%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsGB2312Prober.cpp.o
[ 77%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsMBCSGroupProber.cpp.o
[ 78%] Building CXX object src/CMakeFiles/libuchardet.dir/nsEscSM.cpp.o
[ 79%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsMBCSSM.cpp.o
[ 80%] Building CXX object src/CMakeFiles/libuchardet.dir/nsGB2312Prober.cpp.o
[ 81%] Building CXX object src/CMakeFiles/libuchardet.dir/nsMBCSGroupProber.cpp.o
[ 82%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsSBCSGroupProber.cpp.o
[ 83%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsSBCharSetProber.cpp.o
[ 84%] Building CXX object src/CMakeFiles/libuchardet.dir/nsMBCSSM.cpp.o
[ 85%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsSJISProber.cpp.o
[ 86%] Building CXX object src/CMakeFiles/libuchardet.dir/nsSBCSGroupProber.cpp.o
[ 87%] Building CXX object src/CMakeFiles/libuchardet.dir/nsSBCharSetProber.cpp.o
[ 88%] Building CXX object src/CMakeFiles/libuchardet.dir/nsSJISProber.cpp.o
[ 89%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsUTF8Prober.cpp.o
[ 90%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsLatin1Prober.cpp.o
[ 91%] Building CXX object src/CMakeFiles/libuchardet_static.dir/nsUniversalDetector.cpp.o
[ 92%] Building CXX object src/CMakeFiles/libuchardet.dir/nsUTF8Prober.cpp.o
[ 93%] Building CXX object src/CMakeFiles/libuchardet_static.dir/uchardet.cpp.o
[ 94%] Building CXX object src/CMakeFiles/libuchardet.dir/nsLatin1Prober.cpp.o
[ 95%] Building CXX object src/CMakeFiles/libuchardet.dir/nsUniversalDetector.cpp.o
[ 96%] Linking CXX static library libuchardet.a
[ 97%] Building CXX object src/CMakeFiles/libuchardet.dir/uchardet.cpp.o
[ 97%] Built target libuchardet_static
[ 98%] Linking CXX shared library libuchardet.so
[ 98%] Built target libuchardet
Scanning dependencies of target uchardet-tests
[ 99%] Building C object test/CMakeFiles/uchardet-tests.dir/uchardet-tests.c.o
[100%] Linking C executable uchardet-tests

--- stderr
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: attempted static link of dynamic object `../src/libuchardet.so.0.0.6'
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/uchardet-tests.dir/build.make:96: test/uchardet-tests] Error 1
make[1]: *** [CMakeFiles/Makefile2:198: test/CMakeFiles/uchardet-tests.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
thread 'main' panicked at '
command did not execute successfully, got: exit code: 2

build script failed, must exit now', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.26/src/lib.rs:599
note: Run with `RUST_BACKTRACE=1` for a backtrace.

Build failed, waiting for other jobs to finish...
error: build failed
The command '/bin/sh -c apk add --no-cache 		build-base 		cargo 		cmake 		curl 		curl-dev 		file 		gcc 		openssl 		openssl-dev 		rust && cd /tmp 	&& curl -LO https://github.com/getsentry/sentry-cli/archive/$SENTRY_VERSION.tar.gz 	&& tar -xzf $SENTRY_VERSION.tar.gz 	&& cargo build --manifest-path sentry-cli-$SENTRY_VERSION/Cargo.toml --release 	&& mv sentry-cli-$SENTRY_VERSION/target/release/sentry-cli /usr/local/bin' returned a non-zero code: 101
make: *** [build] Error 101
</pre>
</details>
