### PR TITLE
Fix windows-gnu builds

### DIFF
--- a/uchardet-sys/build.rs
+++ b/uchardet-sys/build.rs
@@ -18,6 +18,8 @@ fn main() {
     // Mustn't build the binaries as they aren't compatible with Windows
     // and cause a compiler error
     config.define("BUILD_BINARY", "OFF");
+    config.define("BUILD_STATIC", "ON");
+    config.define("BUILD_SHARED_LIBS", "OFF");
 
     if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
         // FIXME: This is only needed on newer versions of gcc (>5 ?); Older

--- a/uchardet-sys/build.rs
+++ b/uchardet-sys/build.rs
@@ -6,9 +6,12 @@
 extern crate pkg_config;
 extern crate cmake;
 
+use std::env;
 use cmake::Config;
 
 fn main() {
+    let target = env::var("TARGET").expect("TARGET was not set");
+
     // Do nothing if this package is already provided by the system.
     if pkg_config::find_library("uchardet").is_ok() { return; }
 
@@ -21,12 +24,18 @@ fn main() {
     config.define("BUILD_STATIC", "ON");
     config.define("BUILD_SHARED_LIBS", "OFF");
 
-    if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
+    if target.contains("windows-gnu") {
         // FIXME: This is only needed on newer versions of gcc (>5 ?); Older
         //        versions fail with "unrecognized command line option" and
         //        abort the build; We need to somehow detect the compiler version
         // Disable sized deallocation as we're unable to link when it's enabled
         config.cxxflag("-fno-sized-deallocation");
+    }
+
+    // unset the makeflags (jobserver currently has a bug on this system)
+    // For more information see https://github.com/alexcrichton/jobserver-rs/issues/4
+    if target.contains("windows-gnu") {
+        env::set_var("CARGO_MAKEFLAGS", "");
     }
 
     let dst = config.build();
@@ -36,13 +45,19 @@ fn main() {
     println!("cargo:rustc-link-search=native={}/lib64", dst.display());
     println!("cargo:rustc-link-lib=static=uchardet");
 
-    if !(cfg!(target_os = "windows") && cfg!(target_env = "msvc")) {
-        // Not needed on windows-msvc
-
+    // Not needed on windows-msvc
+    if !target.contains("windows-msvc") {
         // Decide how to link our C++ runtime.  Feel free to submit patches
         // to make this work on your platform.  Other likely options are "c++"
         // and "c++abi" depending on OS and compiler.
         let cxx_abi = "stdc++";
         println!("cargo:rustc-flags=-l {}", cxx_abi);
+    }
+
+    // make TLS work.  For more information see https://github.com/rust-lang/rust/issues/41607
+    // The right fix would be static-nobundle but that is nightly only.
+    if target.contains("windows-gnu") {
+        println!("cargo:rustc-link-lib=dylib=gcc_eh");
+        println!("cargo:rustc-link-lib=dylib=pthread");
     }
 }


### PR DESCRIPTION
This commit fixes builds for windows-gnu. It ensures the following things:

* clobber `CARGO_MAKEFLAGS` to not pass jobserver. This works around https://github.com/alexcrichton/jobserver-rs/issues/4
* force dynamically linking to pthread and gcc_eh, this works around https://github.com/rust-lang/rust/issues/41607 (proper fix would most likely be `static-nobundle` which however is nightly only)
* use the `TARGET` environment variable instead of the macros to correctly support cross compilation to other targets.

The base of this PR is #9.